### PR TITLE
Add prerequisites to README's development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ It contains several authentication mechanisms, private and public endpoints, etc
 
 # development 
 
+## Prerequisites
+
+```bash
+sudo apt install libmysqlclient-dev  # debian/ubuntu
+pip install wheel
+```
+
+## Setting up your local development environment
+
 ```bash
 cd test-api.k6.io
 python3 -m venv .venv


### PR DESCRIPTION
Hi folks,

As described in #6 I ran into some issues when setting up my local development test-api environment. Here's an update to the README that simply adds the missing steps.