### PR TITLE
[feat] Update github action dependencies to remove warning annotations

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,20 +12,20 @@ jobs:
     steps:
       - uses: rlespinasse/github-slug-action@v4
       - name: Check Out Repo 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.K6_DOCKERHUB_USERNAME }}
           password: ${{ secrets.K6_DOCKERHUB_TOKEN }}      
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ./k8s/Dockerfile
@@ -73,9 +73,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.K6_DOCKERHUB_USERNAME }}
           password: ${{ secrets.K6_DOCKERHUB_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,20 +11,20 @@ jobs:
 
     steps:
       - name: Check Out Repo 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.K6_DOCKERHUB_USERNAME }}
           password: ${{ secrets.K6_DOCKERHUB_TOKEN }}      
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ./k8s/Dockerfile


### PR DESCRIPTION
## Ticket(s)

https://github.com/grafana/k6-cloud/issues/2073

## Description

Update dependencies in GitHub action workflows to the latest versions to remove warning annotations during the run and prevent failure to run in the future due to deprecation. 

## Related PR(s)

<!-- - <https://github.com/grafana/...> -->

## Checklist

<!-- Only answer those that apply to your PR: -->

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (internal-wiki and/or k6-docs).
- [ ] I have added tests for my changes.
<!-- - [ ] ANYTHING ELSE -->
